### PR TITLE
Update eviction policy

### DIFF
--- a/build/Cache.js
+++ b/build/Cache.js
@@ -206,7 +206,7 @@ export class ImageCache {
           const path = this.getPath(lowestPriority);
           RNFetchBlob.fs.unlink(path);
           delete this.cache[lowestPriority];
-          lowestPriority = this.policy.lowestPriority();
+          lowestPriority = this.policy.lowestPriority(this.cache);
         }
         this.policy.add(key);
       }

--- a/build/Cache.js
+++ b/build/Cache.js
@@ -6,7 +6,7 @@ const SHA1 = require("crypto-js/sha1");
 const s4 = () => Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
 const BASE_DIR = RNFetchBlob.fs.dirs.DocumentDir + "/imageFiles";
 const QUEUE_DIR = RNFetchBlob.fs.dirs.DocumentDir + "/";
-const CACHE_LIMIT_FILE_COUNT = 5;
+const CACHE_LIMIT_FILE_COUNT = 50;
 
 export class ImageCache {
 

--- a/build/index.js
+++ b/build/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Image, Platform } from "react-native";
+import { Image, Platform, View, ActivityIndicator } from "react-native";
 import RNFetchBlob from "react-native-fetch-blob";
 
 import { ImageCache } from './Cache'

--- a/build/index.js
+++ b/build/index.js
@@ -12,9 +12,9 @@ export class BaseCachedImage extends Component {
     constructor() {
         super();
         this.handler = (path) => {
-            this.setState({ path });
+            this.setState({ path, loading: false });
         };
-        this.state = { path: undefined };
+        this.state = { path: undefined, loading: true };
     }
     dispose() {
       return new Promise((resolve, reject)=> {
@@ -92,7 +92,21 @@ export class CachedImage extends BaseCachedImage {
     }
     render() {
         const props = this.getProps();
-        return React.createElement(Image, Object.assign({}, props), this.props.children);
+        const el = React.createElement(Image, Object.assign({}, props), this.props.children);
+        return (
+          <View style={{ flex: 1 }}>
+            { el }
+            {
+              this.state.loading
+              &&
+              <ActivityIndicator
+                style={{ position: 'absolute', bottom: 8, right: 8 }}
+                animating={true}
+                color={'#527da3'}
+                size='small'/>
+            }
+          </View>
+        )
     }
 }
 export class CustomCachedImage extends BaseCachedImage {
@@ -103,6 +117,20 @@ export class CustomCachedImage extends BaseCachedImage {
         const { component } = this.props;
         const props = this.getProps();
         const Component = component;
-        return React.createElement(Component, Object.assign({}, props), this.props.children);
+        const el = React.createElement(Component, Object.assign({}, props), this.props.children);
+        return (
+          <View style={{ flex: 1 }}>
+            { el }
+            {
+              this.state.loading
+              &&
+              <ActivityIndicator
+                style={{ position: 'absolute', bottom: 8, right: 8 }}
+                animating={true}
+                color={'#527da3'}
+                size='small'/>
+            }
+          </View>
+        )
     }
 }

--- a/build/policies/lru.js
+++ b/build/policies/lru.js
@@ -45,7 +45,14 @@ export class LRUPolicy {
 
     lowestPriority(){
       if (this.queue.getSize() > 0){
-        return this.queue.peek();
+        const currentValue = this.queue.peek()
+        let currentNode = this.map[currentValue]
+        let hasHandlers = this.hasHandlers(currentValue, cache)
+        while(hasHandlers && currentNode){
+          currentNode = currentNode.prev
+          hasHandlers = this.hasHandlers(currentNode.val, cache)
+        }
+        return currentNode.val
       }
     }
 
@@ -55,6 +62,10 @@ export class LRUPolicy {
         this.queue.remove(updateNode)
         this.queue.enqueue(updateNode)
       }
+    }
+
+    hasHandlers(val, cache){
+      return cache[val] && cache[val].handlers.length > 0
     }
 
     hasVal(val){

--- a/build/policies/lru.js
+++ b/build/policies/lru.js
@@ -43,7 +43,7 @@ export class LRUPolicy {
       }
     }
 
-    lowestPriority(){
+    lowestPriority(cache){
       if (this.queue.getSize() > 0){
         const currentValue = this.queue.peek()
         let currentNode = this.map[currentValue]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fibo-app/fibo-imagecache",
-  "version": "0.2.3",
+  "version": "0.3.3",
   "description": "CachedImage component for React native",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fibo-app/fibo-imagecache",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "CachedImage component for React native",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fibo-app/fibo-imagecache",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "CachedImage component for React native",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@fibo-app/fibo-imagecache",
-  "version": "0.3.1",
+  "version": "0.2.3",
   "description": "CachedImage component for React native",
   "main": "build/index.js",
+  "typings": "build/index.d.ts",
   "scripts": {
     "test": "NODE_ENV=TEST mocha --compilers js:babel-core/register"
   },


### PR DESCRIPTION
- [X] checking if image has handlers before evicting, so we dont evict photos that are being used in current view. This also mean, we are going through and evicting every photo that is not being used, or the stop if the cache has not reached capacity - whichever comes first.

- [X] loading indicator when photo is downloading.